### PR TITLE
Add sleep delay before waiting for metrics-server readiness

### DIFF
--- a/testbed/kind/setup.sh
+++ b/testbed/kind/setup.sh
@@ -53,7 +53,7 @@ echo -e "${BBCOLOR}OK${ENDFORMAT}"
 echo -ne "${BCOLOR}Deploy metrics server...${ENDFORMAT}"
 kubectl apply -f "$PWD/metrics-server.yaml" 1> $OUTPUT
 echo -e "${BBCOLOR}OK${ENDFORMAT}"
-
+sleep 5
 echo "Waiting for metrics-server to be ready"
 kubectl wait --for=condition=ready pod -l k8s-app=metrics-server -n kube-system --timeout=360s   
 
@@ -92,7 +92,7 @@ echo -e "${BBCOLOR}OK${ENDFORMAT}"
 echo -ne "${BCOLOR}Deploy Metrics server...${ENDFORMAT}"
 kubectl apply -f "$PWD/metrics-server.yaml" 1> $OUTPUT
 echo -e "${BBCOLOR}OK${ENDFORMAT}"
-
+sleep 5
 echo "Waiting for metrics-server to be ready"
 kubectl wait --for=condition=ready pod -l k8s-app=metrics-server -n kube-system --timeout=360s
 


### PR DESCRIPTION
To avoid an error when setting up the fluidos-edge environment, I added a 5-second delay to ensure that kubectl correctly picks up the metric server resources.

![Screenshot from 2024-12-28 12-50-24](https://github.com/user-attachments/assets/e4c09df5-3736-4ca5-acc2-56b106c409bb)
